### PR TITLE
Add "Clear Charts" Button to Reset Analytics in analyze.html (Closes #128)feat: Add 'Clear Charts' button to reset analytics in analyze.html (c…

### DIFF
--- a/frontend/analyze.html
+++ b/frontend/analyze.html
@@ -69,6 +69,13 @@
             <canvas id="companyChart"></canvas>
           </div>
         </div>
+        <!-- Clear Charts Button -->
+        <div class="card" style="margin-bottom: 2rem;">
+          <button id="clearButton" class="clear-btn">
+            🧹 Clear Charts
+          </button>
+        </div>
+
 
         <div class="gainers-losers">
           <div class="card">

--- a/frontend/css/analyze.css
+++ b/frontend/css/analyze.css
@@ -126,3 +126,17 @@ canvas {
   background-color: #1e1e1e;
   border-radius: 10px;
 }
+.clear-btn {
+  background-color: #ff5252;
+  color: white;
+  border: none;
+  padding: 0.7rem 1.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.clear-btn:hover {
+  background-color: #ff1744;
+}

--- a/frontend/js/analyze.js
+++ b/frontend/js/analyze.js
@@ -138,3 +138,19 @@ function genColors(data) {
   ];
   return Object.keys(data).map((_, i) => base[i % base.length]);
 }
+
+document.getElementById("clearButton").addEventListener("click", () => {
+  // Reset totals
+  document.getElementById("totalInvestment").textContent = "--";
+  document.getElementById("totalPnL").textContent = "--";
+  document.getElementById("avgReturn").textContent = "--";
+  document.getElementById("mostRisky").textContent = "--";
+
+  // Clear charts
+  document.getElementById("sectorChart").getContext("2d").clearRect(0, 0, 400, 400);
+  document.getElementById("companyChart").getContext("2d").clearRect(0, 0, 400, 400);
+
+  // Clear gainers/losers
+  document.getElementById("gainersList").innerHTML = "Upload CSV first";
+  document.getElementById("losersList").innerHTML = "Upload CSV first";
+});


### PR DESCRIPTION
Overview
Introduces a "Clear Charts" button enabling users to reset all analytics content without reloading the page. Improves user experience by supporting quicker analysis cycles.

Key Updates
Clears all chart canvases (sectorChart, companyChart)

Resets gainers/losers lists and all summary metrics

Testing
Uploaded sample CSV to generate analytics

Verified full reset on "Clear Charts" click

No errors, smooth UI behavior

